### PR TITLE
Fix typo "priamry"

### DIFF
--- a/pages/docs/belongs_to.md
+++ b/pages/docs/belongs_to.md
@@ -46,7 +46,7 @@ type Profile struct {
 
 ## Association ForeignKey
 
-For a belongs to relationship, GORM usually use owner's priamry key as the foreign key's value, for above example, it is `User`'s `ID`.
+For a belongs to relationship, GORM usually use owner's primary key as the foreign key's value, for above example, it is `User`'s `ID`.
 
 When you assign a profile to a user, GORM will save user's `ID` into profile's `UserID` field.
 

--- a/pages/docs/conventions.md
+++ b/pages/docs/conventions.md
@@ -31,7 +31,7 @@ type User struct {
 
 ## `ID` as Primary Key
 
-GORM use field with name `ID` as priamry key by default.
+GORM use field with name `ID` as primary key by default.
 
 ```go
 type User struct {

--- a/pages/docs/has_many.md
+++ b/pages/docs/has_many.md
@@ -44,7 +44,7 @@ type CreditCard struct {
 
 ## Association ForeignKey
 
-GORM usually use owner's priamry key as the foreign key's value, for above example, it is `User`'s `ID`,
+GORM usually use owner's primary key as the foreign key's value, for above example, it is `User`'s `ID`,
 
 When you assign credit cards to a user, GORM will save user's `ID` into credit cards' `UserID` field.
 

--- a/pages/docs/many_to_many.md
+++ b/pages/docs/many_to_many.md
@@ -75,7 +75,7 @@ type CustomizeAccount struct {
 
 To define a self-referencing many2many relationship, you have to change association's foreign key in the join table.
 
-to make it different with source's foreign key, which is generated using struct's name and its priamry key, for example:
+to make it different with source's foreign key, which is generated using struct's name and its primary key, for example:
 
 ```go
 type User struct {


### PR DESCRIPTION
Fixes typo in multiple locations `priamry` -> `primary`