### PR TITLE
Fix sidebar overlaying code blocks

### DIFF
--- a/themes/navy/source/css/_partial/highlight.styl
+++ b/themes/navy/source/css/_partial/highlight.styl
@@ -34,6 +34,8 @@ pre
   padding: 10px 15px
   color: highlight-foreground
   overflow: auto
+  position: relative
+  z-index: 100
   margin: 0
   table
     margin: 0 !important


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2672503/45862111-4cdd6580-bd3e-11e8-9be6-ffa877c525dd.png)

After:

![image](https://user-images.githubusercontent.com/2672503/45862118-536bdd00-bd3e-11e8-9d59-73c27776c89e.png)
