### PR TITLE
Load jQuery with the same scheme as the including page

### DIFF
--- a/themes/navy/layout/partial/after_footer.swig
+++ b/themes/navy/layout/partial/after_footer.swig
@@ -4,7 +4,7 @@
 {{ js('js/toc') }}
 {{ js('js/mobile_nav') }}
 
-<script src="http://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="//code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 {{ js('js/code_expander') }}
 {{ js('js/404_fix') }}
 <!-- endbuild -->


### PR DESCRIPTION
This allows GORM to be hosted on secure sites (as an example, on https://gorm.app.render.com) without mixed content warnings.