### PR TITLE
Fix save_associations example GORM tag

### DIFF
--- a/pages/docs/associations.md
+++ b/pages/docs/associations.md
@@ -108,7 +108,7 @@ db.Set("gorm:save_associations", false).Save(&user)
 type User struct {
   gorm.Model
   Name    string
-  Company Company `gorm:"association_autoupdate:false"`
+  Company Company `gorm:"save_associations:false"`
 }
 ```
 


### PR DESCRIPTION
`association_autoupdate` was probably copy pasted from the previous example and not updated.