### PR TITLE
Updated dialects.md

### DIFF
--- a/pages/docs/dialects.md
+++ b/pages/docs/dialects.md
@@ -56,7 +56,7 @@ resultDoc := Document{}
 db.Where("id = ?", sampleDoc.ID).First(&resultDoc)
 
 metadataIsEqual := reflect.DeepEqual(resultDoc.Metadata, sampleDoc.Metadata)
-secretsIsEqual := reflect.DeepEqual(resultDoc.Secrets, resultDoc.Secrets)
+secretsIsEqual := reflect.DeepEqual(resultDoc.Secrets, sampleDoc.Secrets)
 
 // this should print "true"
 fmt.Println("Inserted fields are as expected:", metadataIsEqual && secretsIsEqual)


### PR DESCRIPTION
line 59 (at the time) had a mistake: "secretsIsEqual := reflect.DeepEqual(resultDoc.Secrets, resultDoc.Secrets)"
Changed to: "secretsIsEqual := reflect.DeepEqual(resultDoc.Secrets, sampleDoc.Secrets)"