### PR TITLE
Document the issue #1037

### DIFF
--- a/pages/docs/composite_primary_key.md
+++ b/pages/docs/composite_primary_key.md
@@ -14,4 +14,14 @@ type Product struct {
 }
 ```
 
+Note that integer fields with `primary_key` tag are `auto_increment` by default. That can result in multiple auto-incremented integer primary keys instead of a single composite primary key. 
+
+To create the composite primary key containing ints you need to turn off `auto_increment` for the int fields:
+
+```go
+type Product struct {
+	CategoryID uint64 `gorm:"primary_key;auto_increment:false"`
+	TypeID     uint64 `gorm:"primary_key;auto_increment:false"`
+}
+```
 


### PR DESCRIPTION
I also consider this a bit unexpected behavior. I think ideally the Gorm should see there are more `primary_key` fields in a struct and turn off `auto_increment` for them automatically. And keep `auto_increment` on by default only for the case when there is a single `primary_key` in the struct.

That may be difficult to implement, though. So as long as the current implementation is kept, the documentation should be there to clarify this behaviour.