### PR TITLE
Fixed an error in Scan code example.

### DIFF
--- a/pages/docs/query.md
+++ b/pages/docs/query.md
@@ -445,8 +445,8 @@ type Result struct {
 }
 
 var result Result
-db.Table("users").Select("name, age").Where("name = ?", 3).Scan(&result)
+db.Table("users").Select("name, age").Where("name = ?", "Antonio").Scan(&result)
 
 // Raw SQL
-db.Raw("SELECT name, age FROM users WHERE name = ?", 3).Scan(&result)
+db.Raw("SELECT name, age FROM users WHERE name = ?", "Antonio").Scan(&result)
 ```


### PR DESCRIPTION
Fixed an error. Previous version does a query with an int for a name that is a string. Since I don't think that someone can be called "3" (as int), I fixed it with a real name (mine, just because I'm lazy af).