### PR TITLE
Fix linter warning

### DIFF
--- a/pages/docs/dialects.md
+++ b/pages/docs/dialects.md
@@ -44,7 +44,7 @@ password := "0654857340"
 metadata := json.RawMessage(`{"is_archived": 0}`)
 sampleDoc := Document{
   Body: "This is a test document",
-  Metadata: postgres.Jsonb{ metadata },
+  Metadata: postgres.Jsonb{ RawMessage: metadata },
   Secrets: postgres.Hstore{"password": &password},
 }
 


### PR DESCRIPTION
Fix `go-vet` warning  `composite literal uses unkeyed fields`