### PR TITLE
feat/disambiguation in the migrations doc

### DIFF
--- a/pages/de_DE/docs/migration.md
+++ b/pages/de_DE/docs/migration.md
@@ -7,7 +7,7 @@ layout: page
 
 Automatically migrate your schema, to keep your schema update to date.
 
-**WARNING:** AutoMigrate will **ONLY** create tables, missing columns and missing indexes, and **WON'T** change existing column's type or delete unused columns to protect your data.
+**WARNING:** AutoMigrate will **ONLY** create tables, missing columns and missing indexes, and **WON'T** change existing column's type or delete unused columns to protect your data and also **WON'T** create **relations** between tables such as foreign keys. See **Add Foreign Key** part in the current page.
 
 ```go
 db.AutoMigrate(&User{})


### PR DESCRIPTION
In other ORMs such as Django or SqlAlchemy,... the auto migration command creates all tables and migrations with them.
But in gorm, as I see we haven't this and we should use AddForeignKey to create relations.
I think it's better to say this point at the beginning of the Migration docs.